### PR TITLE
Provide runtime checks for 'soft; dependency on Iris 2.1.

### DIFF
--- a/iris_grib/__init__.py
+++ b/iris_grib/__init__.py
@@ -26,6 +26,7 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import six
 
 import datetime
+import distutils.version
 import math  # for fmod
 import warnings
 
@@ -881,3 +882,15 @@ def save_messages(messages, target, append=False):
         # (this bit is common to the pp and grib savers...)
         if isinstance(target, six.string_types):
             grib_file.close()
+
+
+def _confirm_iris_mercator_support():
+    # Check that Iris version is at least 2.1, required for 'standard_parallel'
+    # support in the Mercator coord-system.
+    # This is a temporary fix allowing us to state Iris>=2.0 as a dependency,
+    # required for this release because Iris 2.1 is not yet available.
+    iris_version = distutils.version.LooseVersion(iris.__version__)
+    min_mercator_version = '2.1.0'
+    if iris_version < min_mercator_version:
+        msg = 'Support for Mercator projections requires Iris version >= {}'
+        raise ValueError(msg.format(min_mercator_version))

--- a/iris_grib/_load_convert.py
+++ b/iris_grib/_load_convert.py
@@ -43,6 +43,7 @@ from iris.fileformats.rules import ConversionMetadata, Factory, Reference, \
     ReferenceTarget
 from iris.util import _is_circular
 
+from . import _confirm_iris_mercator_support
 from ._grib1_load_rules import grib1_convert
 from .message import GribMessage
 
@@ -746,6 +747,9 @@ def grid_definition_template_10(section, metadata):
     # intersects the Earth
     standard_parallel = section['LaD'] * _GRID_ACCURACY_IN_DEGREES
 
+    # Check and raise a more intelligible error, if the Iris version is too old
+    # to support the Mercator 'standard_parallel' keyword.
+    _confirm_iris_mercator_support()
     cs = icoord_systems.Mercator(standard_parallel=standard_parallel,
                                  ellipsoid=geog_cs)
 

--- a/iris_grib/_save_rules.py
+++ b/iris_grib/_save_rules.py
@@ -39,6 +39,7 @@ from iris.coord_systems import (GeogCS, RotatedGeogCS, Mercator,
                                 TransverseMercator, LambertConformal)
 import iris.exceptions
 
+from . import _confirm_iris_mercator_support
 from . import grib_phenom_translation as gptx
 from ._load_convert import (_STATISTIC_TYPE_NAMES, _TIME_RANGE_UNITS)
 from iris.util import is_regular, regular_step
@@ -503,6 +504,9 @@ def grid_definition_template_10(cube, grib):
     gribapi.grib_set(grib, "longitudeOfLastGridPoint",
                      int(np.round(last_x / _DEFAULT_DEGREES_UNITS)))
 
+    # Check and raise a more intelligible error, if the Iris version is too old
+    # to support the Mercator 'standard_parallel' property.
+    _confirm_iris_mercator_support()
     # Encode the latitude at which the projection intersects the Earth.
     gribapi.grib_set(grib, 'LaD',
                      cs.standard_parallel / _DEFAULT_DEGREES_UNITS)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
-import distutils
 import os
 import os.path
 from setuptools import setup
@@ -58,13 +57,6 @@ def file_walk_relative(top, remove=''):
             yield os.path.join(root, file).replace(remove, '')
 
 
-def available_iris():
-    import iris
-    if iris.__version__ >= distutils.version.LooseVersion('2.1.0'):
-        return 'scitools-iris==2.1.*'
-    else:
-        return 'scitools-iris>=2.0.*'
-
 setup_args = dict(
     name             = name,
     version          = extract_version(),
@@ -87,7 +79,12 @@ setup_args = dict(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
     ],
-    install_requires = [available_iris(), 'eccodes'],
+    # NOTE: This Iris version requirement is a purely temporary measure :
+    # Iris>=2.1 is needed for Mercator support, but this is not yet available,
+    # so 'iris_grib._confirm_iris_mercator_support' performs a runtime version
+    # check instead + raises an error if required.
+    # TODO: update Iris version and remove runtime checking, in future release.
+    install_requires = ['scitools-iris>=2.0.*', 'eccodes'],
     extras_require = {
         'test:python_version=="2.7"': ['mock'],
     },


### PR DESCRIPTION
This returns the 'official stated' dependency to just Iris>=2.0, as before.
We want to remove this mechanism in another release, once Iris 2.1 is out.