### PR TITLE
Move mercator version-check to its own submodule, to avoid import problems.

### DIFF
--- a/iris_grib/__init__.py
+++ b/iris_grib/__init__.py
@@ -26,7 +26,6 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 import six
 
 import datetime
-import distutils.version
 import math  # for fmod
 import warnings
 
@@ -882,15 +881,3 @@ def save_messages(messages, target, append=False):
         # (this bit is common to the pp and grib savers...)
         if isinstance(target, six.string_types):
             grib_file.close()
-
-
-def _confirm_iris_mercator_support():
-    # Check that Iris version is at least 2.1, required for 'standard_parallel'
-    # support in the Mercator coord-system.
-    # This is a temporary fix allowing us to state Iris>=2.0 as a dependency,
-    # required for this release because Iris 2.1 is not yet available.
-    iris_version = distutils.version.LooseVersion(iris.__version__)
-    min_mercator_version = '2.1.0'
-    if iris_version < min_mercator_version:
-        msg = 'Support for Mercator projections requires Iris version >= {}'
-        raise ValueError(msg.format(min_mercator_version))

--- a/iris_grib/_iris_mercator_support.py
+++ b/iris_grib/_iris_mercator_support.py
@@ -1,0 +1,40 @@
+# (C) British Crown Copyright 2018, Met Office
+#
+# This file is part of iris-grib.
+#
+# iris-grib is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# iris-grib is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with iris-grib.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Temporary module to check for the extended Mercator class in Iris,
+which iris-grib requires for its Mercator support.
+
+"""
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+import six
+
+import distutils.version
+
+import iris
+
+
+def confirm_extended_mercator_supported():
+    # Check that Iris version is at least 2.1, required for 'standard_parallel'
+    # support in the Mercator coord-system.
+    # This is a temporary fix allowing us to state Iris>=2.0 as a dependency,
+    # required for this release because Iris 2.1 is not yet available.
+    iris_version = distutils.version.LooseVersion(iris.__version__)
+    min_mercator_version = '2.1.0'
+    if iris_version < min_mercator_version:
+        msg = 'Support for Mercator projections requires Iris version >= {}'
+        raise ValueError(msg.format(min_mercator_version))

--- a/iris_grib/_load_convert.py
+++ b/iris_grib/_load_convert.py
@@ -43,7 +43,7 @@ from iris.fileformats.rules import ConversionMetadata, Factory, Reference, \
     ReferenceTarget
 from iris.util import _is_circular
 
-from . import _confirm_iris_mercator_support
+from ._iris_mercator_support import confirm_extended_mercator_supported
 from ._grib1_load_rules import grib1_convert
 from .message import GribMessage
 
@@ -749,7 +749,7 @@ def grid_definition_template_10(section, metadata):
 
     # Check and raise a more intelligible error, if the Iris version is too old
     # to support the Mercator 'standard_parallel' keyword.
-    _confirm_iris_mercator_support()
+    confirm_extended_mercator_supported()
     cs = icoord_systems.Mercator(standard_parallel=standard_parallel,
                                  ellipsoid=geog_cs)
 

--- a/iris_grib/_save_rules.py
+++ b/iris_grib/_save_rules.py
@@ -39,7 +39,7 @@ from iris.coord_systems import (GeogCS, RotatedGeogCS, Mercator,
                                 TransverseMercator, LambertConformal)
 import iris.exceptions
 
-from . import _confirm_iris_mercator_support
+from ._iris_mercator_support import confirm_extended_mercator_supported
 from . import grib_phenom_translation as gptx
 from ._load_convert import (_STATISTIC_TYPE_NAMES, _TIME_RANGE_UNITS)
 from iris.util import is_regular, regular_step
@@ -506,7 +506,7 @@ def grid_definition_template_10(cube, grib):
 
     # Check and raise a more intelligible error, if the Iris version is too old
     # to support the Mercator 'standard_parallel' property.
-    _confirm_iris_mercator_support()
+    confirm_extended_mercator_supported()
     # Encode the latitude at which the projection intersects the Earth.
     gribapi.grib_set(grib, 'LaD',
                      cs.standard_parallel / _DEFAULT_DEGREES_UNITS)


### PR DESCRIPTION
Problem occurs because `iris_grib` already imports from its own submodules, like `iris_grib._load_rules`.
So if the `confirm_xxx` function is defined *in* iris_grib, then `_load_rules` must import it ***from*** `iris_grib`.
But that fails, because the `confirm_xxx` function is not yet defined, at the point where `iris_grib` imported `iris_grib._load_rules` (!!)

You can probably fix it by moving the function definition above the submodule imports, but that is messy and breaks our import style rules.
This way is tidier, I think.